### PR TITLE
chore: update web components dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@fintraffic/fds-coreui-components": "^0.1.0"
+        "@fintraffic/fds-coreui-components": "^0.1.1"
       },
       "devDependencies": {
         "@lit/react": "^1.0.2",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@fintraffic/fds-coreui-components": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fintraffic/fds-coreui-components/-/fds-coreui-components-0.1.0.tgz",
-      "integrity": "sha512-wWpGPXvQv22ZxSZ0X9Dwm70r8h5YqZZ8ggnn/zRllnMZonTIF4noSXHhbJ2JrhU6X58FMzweNGbDf5h3ZYuB0A==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fintraffic/fds-coreui-components/-/fds-coreui-components-0.1.1.tgz",
+      "integrity": "sha512-TtDiqNkISrXXXNSHHmZYwefyauIsbf4YFxabnJhWYqFPv2vhY6aczkIOJrzPVQrhilRHiEZLmSapqNIXmYr+/A==",
       "dependencies": {
         "@fintraffic/fds-coreui-css": "^0.1.0",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Fintraffic",
   "license": "EUPL-1.2",
   "dependencies": {
-    "@fintraffic/fds-coreui-components": "^0.1.0"
+    "@fintraffic/fds-coreui-components": "^0.1.1"
   },
   "devDependencies": {
     "@lit/react": "^1.0.2",


### PR DESCRIPTION
Update `@fintraffic/fds-coreui-components` dependency from 0.1.0 to 0.1.1.