### PR TITLE
fix: add missing js extension to import paths

### DIFF
--- a/src/alert.ts
+++ b/src/alert.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsAlert as _FdsAlert } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-alert'
+import '@fintraffic/fds-coreui-components/dist/define/fds-alert.js'
 
 export { FdsAlertVariant } from '@fintraffic/fds-coreui-components'
 

--- a/src/button.ts
+++ b/src/button.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createComponent } from '@lit/react'
 import { FdsButton as _FdsButton } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-button'
+import '@fintraffic/fds-coreui-components/dist/define/fds-button.js'
 
 export { FdsButtonVariant } from '@fintraffic/fds-coreui-components'
 

--- a/src/card.ts
+++ b/src/card.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsCard as _FdsCard } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-card'
+import '@fintraffic/fds-coreui-components/dist/define/fds-card.js'
 
 export { FdsCardElevation } from '@fintraffic/fds-coreui-components'
 

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsCheckbox as _FdsCheckbox } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-checkbox'
+import '@fintraffic/fds-coreui-components/dist/define/fds-checkbox.js'
 
 export const FdsCheckbox = createComponent({
   tagName: 'fds-checkbox',

--- a/src/combobox.ts
+++ b/src/combobox.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsCombobox as _FdsCombobox, FdsComboboxEvent } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-combobox'
+import '@fintraffic/fds-coreui-components/dist/define/fds-combobox.js'
 
 export { FdsComboboxEvent } from '@fintraffic/fds-coreui-components'
 

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsDialog as _FdsDialog } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-dialog'
+import '@fintraffic/fds-coreui-components/dist/define/fds-dialog.js'
 
 export const FdsDialog = createComponent({
   tagName: 'fds-dialog',

--- a/src/divider.ts
+++ b/src/divider.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createComponent } from '@lit/react'
 import { FdsDivider as _FdsDivider } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-divider'
+import '@fintraffic/fds-coreui-components/dist/define/fds-divider.js'
 
 export const FdsDivider = createComponent({
   tagName: 'fds-divider',

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, ReactWebComponent, createComponent } from '@lit/react'
 import { FdsDropdown as _FdsDropdown, FdsDropdownEvent } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-dropdown'
+import '@fintraffic/fds-coreui-components/dist/define/fds-dropdown.js'
 
 export { FdsDropdownEvent, FdsDropdownOption } from '@fintraffic/fds-coreui-components'
 

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createComponent } from '@lit/react'
 import { FdsIcon as _FdsIcon } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-icon'
+import '@fintraffic/fds-coreui-components/dist/define/fds-icon.js'
 
 export { FdsIcons, FdsIconType } from '@fintraffic/fds-coreui-components'
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsInput as _FdsInput } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-input'
+import '@fintraffic/fds-coreui-components/dist/define/fds-input.js'
 
 export const FdsInput = createComponent({
   tagName: 'fds-input',

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventName, createComponent } from '@lit/react'
 import { FdsNavigation as _FdsNavigation, FdsNavigationItem } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-navigation'
+import '@fintraffic/fds-coreui-components/dist/define/fds-navigation.js'
 
 export {
   FdsNavigationItem,

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createComponent } from '@lit/react'
 import { FdsPopover as _FdsPopover } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-popover'
+import '@fintraffic/fds-coreui-components/dist/define/fds-popover.js'
 
 export { FdsPopoverPosition } from '@fintraffic/fds-coreui-components'
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createComponent } from '@lit/react'
 import { FdsTable as _FdsTable } from '@fintraffic/fds-coreui-components'
-import '@fintraffic/fds-coreui-components/dist/define/fds-table'
+import '@fintraffic/fds-coreui-components/dist/define/fds-table.js'
 
 export { FdsTableItem } from '@fintraffic/fds-coreui-components'
 


### PR DESCRIPTION
`.js` extension is needed for non bare module import paths (paths to specific files in a module). This was missing in most places.